### PR TITLE
Cleanup Macros

### DIFF
--- a/macros/cleanup/_cleanup_macros.yml
+++ b/macros/cleanup/_cleanup_macros.yml
@@ -1,0 +1,41 @@
+version: 2 
+
+macros: 
+  - name: drop_deprecated_tables_and_views
+    description: >
+      This macro will drop all tables and views from the database that are not referenced by dbt. 
+      Objects in the target database belonging to schemas containing dbt sources will remain untouched by this operation.
+      It can be run via __dbt run-operation drop_deprecated_tables_and_views --args '{dry_run: False}'__ . 
+      When run in dry_mode, this macro will return an error if there are any tables or views to be dropped, so that an alert can be set up on it.
+    arguments: 
+      - name: dry_run
+        description: Boolean. Set to false if you really want to drop the tables and views not controled by dbt.
+
+  - name: drop_empty_schemas
+    description: >
+      This macro checks all current database schemas and drops those that do not 
+      contain any views or tables. It can be run via __dbt run-operation drop_empty_schemas --args '{dry_run: False}'__ .
+      To be run after the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+      When run in dry_mode, this macro will return an error if there are any tables or views to be dropped, so that an alert can be set up on it.
+    arguments: 
+      - name: dry_run
+        description: Boolean. Set to false if you really want to drop the empty schemas. 
+
+  - name: get_all_tables_and_views
+    description: >
+      This macro returns a list of tables and views from the target databases as well as the schema name.
+      Snowflake's default metadata schema INFORMATION_SCHEMA is excluded.
+      The macro is used as input for the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+
+  - name: get_dbt_nodes
+    description: >
+      This macro parses the dbt model graph and returns all tables and views.
+      Only models materialized as view, table or incremental and seeds are considered. 
+      Incremental models and seeds are treated as tables. 
+      The macro is used as input for the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+
+  - name: get_dbt_sources_schemas
+    description: >
+      This macro returns a list of all database.schema names contained within the dbt model graph
+      for all sources, if the source exists in the _target_ database.
+      The macro is used as input for the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.

--- a/macros/cleanup/drop_deprecated_tables_and_views.sql
+++ b/macros/cleanup/drop_deprecated_tables_and_views.sql
@@ -1,0 +1,53 @@
+{% macro drop_deprecated_tables_and_views(dry_run=true) %}
+  
+  {# 
+  This macro will drop all tables and views from the database that are not referenced by dbt. 
+  Note: objects belonging to schemas containing dbt sources will remain untouched by this operation.
+  #}
+  
+  {{ log( 'Dropping unknown tables and views. dry_run: ' ~ dry_run , info=true) }}
+  
+  {% set all_tables_and_views = get_all_tables_and_views() %}
+  {% set dbt_tables_and_views = get_dbt_nodes() %}
+  {% set ns = namespace(existsInDbt=false, query='') %}
+  {% set dbt_sources_schemas = get_dbt_sources_schemas() %}
+  {% set model_counter = [] %}
+
+  {{ log( 'Starting to drop non-dbt tables and views. dry_run: ' ~ dry_run , info=true) }}
+  {% for relation in all_tables_and_views %}
+    {% if relation.schema not in dbt_sources_schemas %}
+
+      {% set ns.existsInDbt = false %}
+      {% for node in dbt_tables_and_views %}
+        {% if relation.schema.upper() == node.schema.upper() and relation.name.upper() == node.name.upper() %}
+          {% set ns.existsInDbt = true %}
+        {% endif %}
+      {% endfor %}
+
+      {# Only drop objects that do not exist in dbt  #}
+      {% if not ns.existsInDbt %}
+        
+        {% if relation.type == 'view' %}
+          {% set ns.query = 'DROP VIEW IF EXISTS ' + relation.schema + '.' + relation.name %}
+        {% else %}
+          {% set ns.query = 'DROP TABLE IF EXISTS ' + relation.schema + '.' + relation.name %}
+        {% endif %}
+
+        {{ log( ns.query , info=true) }}
+        {% set __ = model_counter.append(1) %}
+
+        {% if not dry_run %}
+          {% do run_query(ns.query) %}
+        {% endif %}
+
+      {% endif %}
+    {% endif %}
+    
+  {% endfor %}
+
+  {# error on this macro during dry-run so we can set up an alert #}
+  {% if model_counter|length > 0 and dry_run %}
+  {{ exceptions.raise_compiler_error("The Cleanup Job has found " ~ model_counter|length ~ " deprecated table(s) or view(s) to be dropped  (Dry-Run).") }}
+  {% endif %}
+
+{% endmacro %}

--- a/macros/cleanup/drop_deprecated_tables_and_views.sql
+++ b/macros/cleanup/drop_deprecated_tables_and_views.sql
@@ -7,10 +7,10 @@
   
   {{ log( 'Dropping unknown tables and views. dry_run: ' ~ dry_run , info=true) }}
   
-  {% set all_tables_and_views = get_all_tables_and_views() %}
-  {% set dbt_tables_and_views = get_dbt_nodes() %}
+  {% set all_tables_and_views = dna_public_dbt_macros.get_all_tables_and_views() %}
+  {% set dbt_tables_and_views = dna_public_dbt_macros.get_dbt_nodes() %}
   {% set ns = namespace(existsInDbt=false, query='') %}
-  {% set dbt_sources_schemas = get_dbt_sources_schemas() %}
+  {% set dbt_sources_schemas = dna_public_dbt_macros.get_dbt_sources_schemas() %}
   {% set model_counter = [] %}
 
   {{ log( 'Starting to drop non-dbt tables and views. dry_run: ' ~ dry_run , info=true) }}

--- a/macros/cleanup/drop_empty_schemas.sql
+++ b/macros/cleanup/drop_empty_schemas.sql
@@ -1,0 +1,39 @@
+{% macro drop_empty_schemas(dry_run=true) %}
+  
+  {# 
+  This macro checks all current database schemas and drops those that do not 
+  contain any views or tables 
+  #}
+
+  {{ log( 'drop_empty_schemas: Dropping all schemas from database that contain no table/views' , info=true) }}
+  {% set schema_results = run_query('SHOW SCHEMAS') %}
+  {% set all_schemas = schema_results.columns[1].values() %}
+  {% set all_tables_and_views = [] %}
+  {% set empty_schema_counter = [] %}
+
+  {% for schema in all_schemas %}
+    
+    {% if schema != "INFORMATION_SCHEMA" %}
+      {% set view_results = run_query('SHOW VIEWS IN ' ~ schema) %}
+      {% set table_results = run_query('SHOW TABLES IN ' ~ schema) %}
+
+      {# Only drop if schema is empty #}
+      {% if view_results|length == 0 and table_results|length == 0 %}
+        {% set query = 'DROP SCHEMA ' + schema %}
+        {{ log( query , info=true) }}
+        {% set __ = empty_schema_counter.append(1) %}
+
+        {% if not dry_run %}
+          {% do run_query(query) %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+
+  {% endfor %}
+
+  {# error on this macro during dry-run so we can set up an alert #}
+  {% if empty_schema_counter|length > 0 and dry_run %}
+  {{ exceptions.raise_compiler_error("The Cleanup Job has found " ~ empty_schema_counter|length ~ " empty schema(s) to be dropped (Dry-Run).") }}
+  {% endif %}
+
+{% endmacro %}

--- a/macros/cleanup/get_all_tables_and_views.sql
+++ b/macros/cleanup/get_all_tables_and_views.sql
@@ -1,0 +1,35 @@
+{% macro get_all_tables_and_views() %}
+
+  {# 
+  This macro returns a list of tables and views from the target databases as well as the schema name
+  Snowflake's default metadata schema INFORMATION_SCHEMA is excluded.
+  #}
+
+  
+  {{ log( 'get_all_tables_and_views: Loading views and tables from database' , info=true) }}
+  {% set schema_results = run_query('SHOW SCHEMAS') %}
+  {% set all_schemas = schema_results.columns[1].values() %}
+  {% set all_tables_and_views = [] %}
+
+  {% for schema in all_schemas %}
+  {% if schema != "INFORMATION_SCHEMA" %}
+    {% set view_results = run_query('SHOW VIEWS IN ' ~ schema) %}
+    {% set views_in_schema = view_results.columns[1].values() %}
+    {% for name in views_in_schema %}
+      {% set view = {'schema': schema, 'name': name, 'type': 'view'} %}
+      {{ log( view , info=true) }}
+      {% do all_tables_and_views.append(view) %}
+    {% endfor %}
+
+    {% set table_results = run_query('SHOW TABLES IN ' ~ schema) %}
+    {% set tables_in_schema = table_results.columns[1].values() %}
+    {% for name in tables_in_schema %}
+      {% set table = {'schema': schema, 'name': name, 'type': 'table'} %}
+      {{ log( table , info=true) }}
+      {% do all_tables_and_views.append(table) %}
+    {% endfor %}
+  {% endif %}
+  {% endfor %}
+
+  {{ return(all_tables_and_views) }}
+{% endmacro %}

--- a/macros/cleanup/get_dbt_nodes.sql
+++ b/macros/cleanup/get_dbt_nodes.sql
@@ -1,0 +1,37 @@
+{% macro get_dbt_nodes() %}
+  
+  {# 
+  This macro parses the dbt model graph and returns all tables and views
+  
+  Note:
+  Only models materialized as view, table or incremental and seeds are considered. 
+  Incremental models and seeds are treated as tables. 
+  #}
+
+  {{ log( 'get_dbt_nodes: Loading views and tables from dbt graph' , info=true) }}  
+  {% set dbt_tables_and_views = [] %}
+  {% set table_materializations = ["table", "incremental", "seed"] %}
+  {% set all_materializations = ["view", "table", "incremental", "seed"] %}
+  {% set table_resource_types = ["model", "seed"] %}
+  
+  {% for node in graph.nodes.values() %}    
+    {% if node.resource_type in table_resource_types and node.config.get('materialized', 'none') in all_materializations %}
+
+    {# Set the table/view name as alias instead of node name if alias exists #}
+    {% set node_name = node.config.get('alias') if node.config.get('alias') else node.name %}
+      
+      {# Set the node_type type as either table or view. #}
+      {% if node.config.get('materialized', 'table') in table_materializations %}
+        {% set node_type = "table" %}
+      {% else %}
+        {% set node_type = "view" %}
+      {% endif %}
+      
+      {% set node = {'schema': node.schema.upper(), 'name': node_name, 'type': node_type} %}
+      {{ log( node , info=true) }}
+      {% do dbt_tables_and_views.append(node) %}
+    {% endif %}
+  {% endfor %}
+
+  {{ return(dbt_tables_and_views) }}
+{% endmacro %}

--- a/macros/cleanup/get_dbt_sources_schemas.sql
+++ b/macros/cleanup/get_dbt_sources_schemas.sql
@@ -1,0 +1,20 @@
+{% macro get_dbt_sources_schemas() %}
+  
+  {# 
+  This macro returns a list of all database.schema names contained within the dbt model graph
+  for all sources that exist in the target database.
+  #}
+  
+  {% set dbt_sources_schemas = [] %}
+  {% for node in graph.sources.values() %}
+    {% if node.schema is not none and node.database.upper() == target.database.upper() %}
+      {% if node.schema.upper() not in dbt_sources_schemas %}
+        {% set msg ='Found source schema in target database: ' + node.database + '.' + node.schema %}
+        {{ log( msg , info=true) }}
+        {% do dbt_sources_schemas.append(node.schema.upper()) %}
+      {% endif %}      
+    {% endif %}
+  {% endfor %}
+
+  {{ return(dbt_sources_schemas) }}
+{% endmacro %}


### PR DESCRIPTION
Why?
---
This set of macros allows for cleanup of deprecated tables and schemas in our Snowflake databases, that the dbt SP has created.

https://bestjira.atlassian.net/browse/BA-1062

What?
---
- adding cleanup folder with macros

Test
---
we have run these macros successfully a few months in the CONS domain. we ran it with a dry-run job, that fails if there are deprecated models/schemas, and triggered the actual cleanup job manually afterwards.

tested from this repo/PR (locally run): https://github.com/BESTSELLER/dna-cons-dbt/pull/29

breaking change?
---
No.