### PR TITLE
schema name depending on generate_schema_name()

### DIFF
--- a/macros/cleanup/get_dbt_nodes.sql
+++ b/macros/cleanup/get_dbt_nodes.sql
@@ -14,11 +14,14 @@
   {% set all_materializations = ["view", "table", "incremental", "seed"] %}
   {% set table_resource_types = ["model", "seed"] %}
   
-  {% for node in graph.nodes.values() %}    
+  {% for node in graph.nodes.values() %}
     {% if node.resource_type in table_resource_types and node.config.get('materialized', 'none') in all_materializations %}
 
     {# Set the table/view name as alias instead of node name if alias exists #}
     {% set node_name = node.config.get('alias') if node.config.get('alias') else node.name %}
+    {# Set the schema to what we define in the generate_schema_macro #}
+    {% set schema_name = generate_schema_name(node.config.get('schema'), node) %}
+
       
       {# Set the node_type type as either table or view. #}
       {% if node.config.get('materialized', 'table') in table_materializations %}
@@ -27,7 +30,7 @@
         {% set node_type = "view" %}
       {% endif %}
       
-      {% set node = {'schema': node.schema.upper(), 'name': node_name, 'type': node_type} %}
+      {% set node = {'schema': schema_name, 'name': node_name, 'type': node_type} %}
       {{ log( node , info=true) }}
       {% do dbt_tables_and_views.append(node) %}
     {% endif %}


### PR DESCRIPTION
WHY?
---
the cleanup macros have trouble with custom schemas. they assume (correctly in dev and test, but worngly in prod) that the schema is always default_schema.
but we use a custom generated schema name, that is different in prod, and leads to funny problems. in this case, the cleanup macro thinks that the e.g. NEDAP views should be in a ANALYTICS_NEDAP schema, and wants to remove the ones that are located in the NEDAP schema.

what?
---
replacing schema name with the one from the custom generated schema.

Test
---
- was fine in dev. 
- have tested in prod in RETL project: https://emea.dbt.com/deploy/16/projects/806/runs/3365583
- test in WHSA project: what happens if the generate_custom_schema macro is not defined in a project? outcome: it still runs. the in-project defined macro is just overwriting the default macro, so it still exists and yields results.

breaking change
---
No.