### PR TITLE
Adding exception file and routine for cleanup

### DIFF
--- a/macros/cleanup/_cleanup_macros.yml
+++ b/macros/cleanup/_cleanup_macros.yml
@@ -39,3 +39,14 @@ macros:
       This macro returns a list of all database.schema names contained within the dbt model graph
       for all sources, if the source exists in the _target_ database.
       The macro is used as input for the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+
+  - name: get_exception_schemas
+    description: >
+      This macro returns a list of all schemas that are supposed to be ignored when either the drop_deprecated_tables_and_views or the drop_empty_schemas macro is run. The list gets compiled from a seed file called 'cleanup_exceptions.csv'. If any objects are defined in that file, then the seed file from the dna-public-dbt-macros repo needs to be disabled in the project's dbt_project.yml file.
+      The macro is used as input for the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+
+  - name: get_exception_tables_views
+    description: >
+      This macro returns a list of all table and view objects (incl schema name) that are supposed to be ignored when the drop_deprecated_tables_and_views macro is run. The list gets compiled from a seed file called 'cleanup_exceptions.csv'. If any objects are defined in that file, then the seed file from the dna-public-dbt-macros repo needs to be disabled in the project's dbt_project.yml file.
+      The macro is used as input for the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+  

--- a/macros/cleanup/drop_deprecated_tables_and_views.sql
+++ b/macros/cleanup/drop_deprecated_tables_and_views.sql
@@ -11,16 +11,20 @@
   {% set dbt_tables_and_views = dna_public_dbt_macros.get_dbt_nodes() %}
   {% set ns = namespace(existsInDbt=false, query='') %}
   {% set dbt_sources_schemas = dna_public_dbt_macros.get_dbt_sources_schemas() %}
+  {% set excluded_schemas = dna_public_dbt_macros.get_exception_schemas() %}
+  {% set excluded_objects = dna_public_dbt_macros.get_exception_tables_views() %}
   {% set model_counter = [] %}
 
   {{ log( 'Starting to drop non-dbt tables and views. dry_run: ' ~ dry_run , info=true) }}
   {% for relation in all_tables_and_views %}
-    {% if relation.schema not in dbt_sources_schemas %}
+    {% if relation.schema not in dbt_sources_schemas and relation.schema not in excluded_schemas %}
 
       {% set ns.existsInDbt = false %}
       {% for node in dbt_tables_and_views %}
         {% if relation.schema.upper() == node.schema.upper() and relation.name.upper() == node.name.upper() %}
+        {% if relation.schema.upper() ~ '.' ~ relation.name.upper() in excluded_objects %}
           {% set ns.existsInDbt = true %}
+        {% endif %}
         {% endif %}
       {% endfor %}
 

--- a/macros/cleanup/drop_deprecated_tables_and_views.sql
+++ b/macros/cleanup/drop_deprecated_tables_and_views.sql
@@ -21,10 +21,8 @@
 
       {% set ns.existsInDbt = false %}
       {% for node in dbt_tables_and_views %}
-        {% if relation.schema.upper() == node.schema.upper() and relation.name.upper() == node.name.upper() %}
-        {% if relation.schema.upper() ~ '.' ~ relation.name.upper() in excluded_objects %}
+        {% if (relation.schema.upper() == node.schema.upper() and relation.name.upper() == node.name.upper()) or ( relation.schema.upper() ~ '.' ~ relation.name.upper() in excluded_objects) %}
           {% set ns.existsInDbt = true %}
-        {% endif %}
         {% endif %}
       {% endfor %}
 

--- a/macros/cleanup/drop_empty_schemas.sql
+++ b/macros/cleanup/drop_empty_schemas.sql
@@ -8,12 +8,13 @@
   {{ log( 'drop_empty_schemas: Dropping all schemas from database that contain no table/views' , info=true) }}
   {% set schema_results = run_query('SHOW SCHEMAS') %}
   {% set all_schemas = schema_results.columns[1].values() %}
+  {% set excluded_schemas = get_exception_schemas() %}
   {% set all_tables_and_views = [] %}
   {% set empty_schema_counter = [] %}
 
   {% for schema in all_schemas %}
     
-    {% if schema != "INFORMATION_SCHEMA" %}
+    {% if schema != "INFORMATION_SCHEMA" and schema not in excluded_schemas%}
       {% set view_results = run_query('SHOW VIEWS IN ' ~ schema) %}
       {% set table_results = run_query('SHOW TABLES IN ' ~ schema) %}
 

--- a/macros/cleanup/get_exception_schemas.sql
+++ b/macros/cleanup/get_exception_schemas.sql
@@ -1,0 +1,17 @@
+{% macro get_exception_schemas() %}
+  
+  {# 
+  This macro returns a list of all schemas that should get excluded by the cleanup macros by entry in the cleanup_exceptions.csv file.
+  #}
+
+  {% set excluded_schemas = [] %}
+  {% set exclude_schemas = dbt_utils.get_column_values(table=ref('cleanup_exceptions'), column='schema_name', where="object_type='schema'") %}
+  {% for schema in exclude_schemas %}
+    {% set msg ='Found schema in exceptions: ' ~ schema.upper() %}
+    {{ log( msg , info=true) }}
+    {% do excluded_schemas.append(schema.upper()) %}
+  {% endfor %}
+
+  {{ return(excluded_schemas) }}
+
+{% endmacro %}

--- a/macros/cleanup/get_exception_schemas.sql
+++ b/macros/cleanup/get_exception_schemas.sql
@@ -6,11 +6,13 @@
 
   {% set excluded_schemas = [] %}
   {% set exclude_schemas = dbt_utils.get_column_values(table=ref('cleanup_exceptions'), column='schema_name', where="object_type='schema'") %}
+  {% if exclude_schemas %}
   {% for schema in exclude_schemas %}
     {% set msg ='Found schema in exceptions: ' ~ schema.upper() %}
     {{ log( msg , info=true) }}
     {% do excluded_schemas.append(schema.upper()) %}
   {% endfor %}
+  {% endif %}
 
   {{ return(excluded_schemas) }}
 

--- a/macros/cleanup/get_exception_tables_views.sql
+++ b/macros/cleanup/get_exception_tables_views.sql
@@ -1,0 +1,24 @@
+{% macro get_exception_tables_views() %}
+  
+  {# 
+  This macro returns a list of all tables and views that should get excluded by the cleanup macros by entry in the cleanup_exceptions.csv file. It makes no difference if an object is declared as view or table in the exceptions file.
+  #}
+
+{% set excluded_objects = [] %}
+
+{% set sql_query %}
+    select distinct upper(schema_name) || '.' || upper(object_name) as full_name from {{ ref('cleanup_exceptions') }} where lower(object_type) in ('view','table')
+{% endset %}
+{% set exclude_objects = dbt_utils.get_query_results_as_dict(sql_query) %}
+
+{% if exclude_objects %}
+  {% for object in exclude_objects['FULL_NAME'] %}
+    {% set msg ='Found view/table in exceptions: ' ~ object %}
+    {{ log( msg , info=true) }}
+    {% do excluded_objects.append(object) %}
+  {% endfor %}
+{% endif %}
+
+{{ return(excluded_objects) }}
+
+{% endmacro %}

--- a/seeds/cleanup_exceptions.csv
+++ b/seeds/cleanup_exceptions.csv
@@ -1,0 +1,1 @@
+object_type,schema_name,object_name,comment


### PR DESCRIPTION
Why?
---
to be able to define schemas, views or tables that will NOT get dropped when the drop-schema/object macros are run. e.g. files manually added to the prod database, or snapshot files.

What?
---
- adding seed file template - if anything is supposed to be excluded, this file needs to be copied over to the respective repo, and the seed table from this project needs to be disabled via "dna_public_dbt_macros: cleanup_exceptions: +enabled: false"
- adding 2 utility macros that read out contents from the exception file
- adding code in the drop_empty_schemas & drop deprecated_tables_and_views macros, so that exceptions get ignored

Test
---
via cons domain: https://github.com/BESTSELLER/dna-cons-dbt/pull/35

breaking change?
---
no, old code should run as expected, since seed file exists on repo, and is empty