### PR TITLE
das-1301 - Add handling of versioned models

### DIFF
--- a/macros/cleanup/get_dbt_nodes.sql
+++ b/macros/cleanup/get_dbt_nodes.sql
@@ -1,8 +1,8 @@
 {% macro get_dbt_nodes() %}
-  
+
   {# 
   This macro parses the dbt model graph and returns all tables and views
-  
+
   Note:
   Only models materialized as view, table or incremental and seeds are considered. 
   Incremental models and seeds are treated as tables. 
@@ -13,26 +13,38 @@
   {% set table_materializations = ["table", "incremental", "seed"] %}
   {% set all_materializations = ["view", "table", "incremental", "seed"] %}
   {% set table_resource_types = ["model", "seed"] %}
-  
+
+
   {% for node in graph.nodes.values() %}
     {% if node.resource_type in table_resource_types and node.config.get('materialized', 'none') in all_materializations %}
+            {# use this is you want the full json: {{ log( node , info=true) }} #}
 
-    {# Set the table/view name as alias instead of node name if alias exists #}
-    {% set node_name = node.config.get('alias') if node.config.get('alias') else node.name %}
-    {# Set the schema to what we define in the generate_schema_macro #}
-    {% set schema_name = generate_schema_name(node.config.get('schema'), node) %}
+            {# Set the schema to what we define in the generate_schema_macro #}
+            {% set schema_name = generate_schema_name(node.config.get('schema'), node) %}
 
-      
-      {# Set the node_type type as either table or view. #}
-      {% if node.config.get('materialized', 'table') in table_materializations %}
-        {% set node_type = "table" %}
-      {% else %}
-        {% set node_type = "view" %}
-      {% endif %}
-      
-      {% set node = {'schema': schema_name, 'name': node_name, 'type': node_type} %}
-      {{ log( node , info=true) }}
-      {% do dbt_tables_and_views.append(node) %}
+            {# obtaining version #}
+            {% if node.version is number %}
+                {% set node_version = ['_V', node.version]|join %}
+            {% else %}
+                {% set node_version = '' %}
+            {% endif %}
+
+            {# Set the table/view name as alias instead of node name if alias exists, account for versioning #}
+            {% set node_name = node.config.get('alias') 
+                if node.config.get('alias')  
+                else [node.name, node_version]|join %}
+
+
+            {# Set the node_type type as either table or view. #}
+            {% if node.config.get('materialized', 'table') in table_materializations %}
+                {% set node_type = "table" %}
+            {% else %}
+                {% set node_type = "view" %}
+            {% endif %}
+
+            {% set node = {'schema': schema_name, 'name': node_name, 'type': node_type} %}
+            {{ log( node , info=true) }}
+            {% do dbt_tables_and_views.append(node) %}
     {% endif %}
   {% endfor %}
 


### PR DESCRIPTION
Added a block of code to the get_dbt_nodes macro such that it can handle [versioned models](https://docs.getdbt.com/docs/collaborate/govern/model-versions)

Why?
---
In the Merchandising Data Science Team we recently adopted the `drop_deprecated_tables_and_views()` macro to help keep our Snowflake environment in a clean state and avoid clutter (deprecated tables living on).
However, we realized that the current version of this macro can't handle versioned models.
Hence we decided to extend the macro to be able to handle versioned models.

What?
---
Added handling of versioned models to the `get_dbt_nodes()` macro.

Test
---
Tests have been done on [dna-mrch-dbt](https://github.com/BESTSELLER/dna-mrch-dbt) with success.

Breaking Change?
---
No, these changes should not be breaking. In case versioning of models is not used in the repository, the macros should behave exactly as before.
