### PR TITLE
Make sure snapshots models are not deleted by the clean-up procedure

### DIFF
--- a/macros/cleanup/get_dbt_nodes.sql
+++ b/macros/cleanup/get_dbt_nodes.sql
@@ -11,8 +11,8 @@
   {{ log( 'get_dbt_nodes: Loading views and tables from dbt graph' , info=true) }}  
   {% set dbt_tables_and_views = [] %}
   {% set table_materializations = ["table", "incremental", "seed"] %}
-  {% set all_materializations = ["view", "table", "incremental", "seed"] %}
-  {% set table_resource_types = ["model", "seed"] %}
+  {% set all_materializations = ["view", "table", "incremental", "seed", "snapshot"] %} 
+  {% set table_resource_types = ["model", "seed", "snapshot"] %}
 
 
   {% for node in graph.nodes.values() %}


### PR DESCRIPTION
Why?
---
This PR aims to make sure that snapshots models are not deleted by the clean-up procedure.

What?
---
Added snapshots to the `get_dbt_nodes()` macro to make sure snapshots models are identified as dbt nodes.

Test
---
Tested locally.

Breaking Change?
---
No.
