### PR TITLE
Adding column data types to cleanup_exceptions

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,5 +6,14 @@ profile: 'default'
 
 macro-paths: ["macros"]
 
+seeds:
+  dna_public_dbt_macros:
+    cleanup_exceptions:
+      +column_types:
+        object_type: varchar(16777216)
+        schema_name: varchar(16777216)
+        object_name: varchar(16777216)
+        comment: varchar(16777216)
+
 ## this dbt project is not supposed to do anything
 ## it's only the place where we store shared macros


### PR DESCRIPTION
> [!IMPORTANT]  
> Don't expose any internal or business critical information to this public repository!

Why?
---
When building a project with the dna_public_dbt_macros package installed, a cleanup_exceptions table is built with all columns given the data type 'NUMBER(38,0)'.
If a user later wants to use the cleanup_exceptions, the build will fail with the following error:
```
Database Error in seed cleanup_exceptions (seeds/cleanup_exceptions.csv)
  100038 (22018): Numeric value 'VIEW' is not recognized
```

We tried to use the cleanup_exceptions in the Tech Buying project, to clean up tables without deleting a view created outside dbt.
We were unable to build the cleanup_exceptions until we dropped the existing table. 

What?
---
The added code sets the column types to varchar, in order to avoid the above error.

This fix will work for projects that do not already have the dna_public_dbt_macros package installed.

Test
---
I have tested the changes. 
If the table is not already built, it will be built with the correct data types. 
If the table is built with the wrong data types, nothing will happen.

Breaking Change?
---
N
The project will build without problems. 

**PLEASE NOTE:**
If cleanup_exceptions values are added in a project with an existing empty cleanup_exceptions table of the current version, the build will fail. The existing cleanup_exceptions will then need to be dropped, before the project will build.
If an empty cleanup_exceptions table of the current version does not exist in the project, this change will make sure that an empty table is built with the correct data types, so it will be usable when needed.

I have not been able to change the data types, without dropping the existing table - Is it possible?

